### PR TITLE
Normalize base path routing

### DIFF
--- a/internal/core/app.go
+++ b/internal/core/app.go
@@ -123,10 +123,15 @@ func (a *App) Start(ctx context.Context, opt StartOptions) error {
 	}
 
 	// 7) Routes
+	basePath := config.NormalizeBasePath(opt.Config.Server.BasePath)
+	opt.Config.Server.BasePath = basePath
+
+	baseGroup := a.E.Group(basePath)
+
 	for _, m := range mods {
 		a.L.Info("registering routes", slog.String("module", m.Name()))
 
-		if err := m.Routes(a.E, a.C); err != nil {
+		if err := m.Routes(baseGroup, a.C); err != nil {
 			return fmt.Errorf("core.App: routes failed for module %s: %w", m.Name(), err)
 		}
 	}

--- a/internal/core/module.go
+++ b/internal/core/module.go
@@ -24,8 +24,8 @@ type Module interface {
 	Provide(ctx context.Context, c *Container) error
 
 	// Routes registers the HTTP routes of the module.
-	// There is no need to start the server here, just register in e.
-	Routes(e *echo.Echo, c *Container) error
+	// There is no need to start the server here, just register in the provided group.
+	Routes(g *echo.Group, c *Container) error
 
 	// Start initiates background routines, consumers, etc.
 	// Returns a stop function for graceful shutdown.

--- a/internal/modules/aiproxy/infra/http/routes.go
+++ b/internal/modules/aiproxy/infra/http/routes.go
@@ -1,13 +1,11 @@
 package http
 
-import (
-	"github.com/labstack/echo/v4"
-)
+import "github.com/labstack/echo/v4"
 
 // RegisterRoutes wires all HTTP routes for the AI proxy module.
-func RegisterRoutes(e *echo.Echo, basePath string, handler *Handlers) {
-	// Public data-plane routes (explicit base path to match the HTTP server prefix).
-	v1 := e.Group(basePath + "/v1")
+func RegisterRoutes(g *echo.Group, handler *Handlers) {
+	// Public data-plane routes
+	v1 := g.Group("/v1")
 	v1.POST("/chat/completions", handler.ChatCompletions)
 	v1.POST("/embeddings", handler.Embeddings)
 	// You can also register health checks, etc., here if desired.

--- a/internal/modules/aiproxy/module.go
+++ b/internal/modules/aiproxy/module.go
@@ -59,11 +59,10 @@ func (m *module) Migrations(ctx context.Context, c *core.Container) ([]core.Migr
 
 // Routes registers HTTP routes handled by this module.
 // It wires the AI proxy HTTP endpoints to Echo using the previously built dependencies.
-func (m *module) Routes(e *echo.Echo, c *core.Container) error {
+func (m *module) Routes(g *echo.Group, c *core.Container) error {
 	log := c.Logger()
 	log.Info("aiproxy: registering routes")
 
-	conf := c.Config()
 	deps := MustDepsFromContainer(c)
 
 	handlers := http.NewHandlers(
@@ -74,7 +73,7 @@ func (m *module) Routes(e *echo.Echo, c *core.Container) error {
 		deps.Service, // [app.EmbeddingsUseCase]
 	)
 
-	http.RegisterRoutes(e, conf.Server.BasePath, handlers)
+	http.RegisterRoutes(g, handlers)
 
 	return nil
 }

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -34,6 +34,8 @@ func loadEnv() *Config {
 		panic(err)
 	}
 
+	c.Server.Normalize()
+
 	return &c
 }
 

--- a/internal/platform/config/http.go
+++ b/internal/platform/config/http.go
@@ -1,15 +1,40 @@
 package config
 
-import "time"
+import (
+	"strings"
+	"time"
+)
 
 type HTTPServer struct {
 	Host           string        `env:"HOST"            envDefault:"0.0.0.0"`
 	Port           int           `env:"PORT"            envDefault:"8081"`
-	BasePath       string        `env:"BASE_PATH"       envDefault:"/api/v1"`
+	BasePath       string        `env:"BASE_PATH"       envDefault:"/api"`
 	ReadTimeout    time.Duration `env:"READ_TIMEOUT"    envDefault:"5s"`
 	AllowedOrigins []string      `env:"ALLOWED_ORIGINS" envSeparator:","`
 
 	TLSCertFile string `env:"TLS_CERTFILE"`
 	TLSKeyFile  string `env:"TLS_KEYFILE"`
 	EnableTLS   bool   `env:"ENABLE_TLS"`
+}
+
+// Normalize ensures the configured base path is standardized before being used across the app.
+// It guarantees a single leading slash and removes trailing slashes, except when the base path
+// represents the root.
+func (h *HTTPServer) Normalize() {
+	h.BasePath = NormalizeBasePath(h.BasePath)
+}
+
+// NormalizeBasePath standardizes base paths used by the HTTP server.
+func NormalizeBasePath(basePath string) string {
+	basePath = strings.TrimSpace(basePath)
+
+	if basePath == "" || basePath == "/" {
+		return ""
+	}
+
+	if !strings.HasPrefix(basePath, "/") {
+		basePath = "/" + basePath
+	}
+
+	return strings.TrimSuffix(basePath, "/")
 }

--- a/internal/platform/database/module.go
+++ b/internal/platform/database/module.go
@@ -44,7 +44,7 @@ func (m *module) Provide(ctx context.Context, c *core.Container) error {
 }
 
 // Routes implements core.Module.
-func (m *module) Routes(e *echo.Echo, c *core.Container) error { return nil }
+func (m *module) Routes(g *echo.Group, c *core.Container) error { return nil }
 
 // Start implements core.Module.
 func (m *module) Start(ctx context.Context, c *core.Container) (stop func(context.Context) error, err error) {

--- a/internal/platform/guardrails/simple_engine.go
+++ b/internal/platform/guardrails/simple_engine.go
@@ -70,6 +70,7 @@ func (e *simpleEngine) applyRules(
 
 	phase := PhaseInput
 	messages := gx.InputMessages
+
 	if !isInput {
 		phase = PhaseOutput
 		messages = gx.OutputMessages

--- a/internal/platform/httpx/server.go
+++ b/internal/platform/httpx/server.go
@@ -14,6 +14,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/jeanmolossi/kalika-eco-ai-proxy/internal/platform/config"
 	"github.com/jeanmolossi/kalika-eco-ai-proxy/internal/platform/logger"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
@@ -44,6 +45,8 @@ func Start(cfg Config) func(ctx context.Context, e *echo.Echo) func(context.Cont
 	if cfg.AllowedOrigins == nil {
 		cfg.AllowedOrigins = []string{}
 	}
+
+	cfg.BasePath = config.NormalizeBasePath(cfg.BasePath)
 
 	allowedMethods := []string{
 		http.MethodGet,
@@ -104,7 +107,8 @@ func Start(cfg Config) func(ctx context.Context, e *echo.Echo) func(context.Cont
 
 		e.Use(middlewares...)
 
-		registerInfraRoutes(e, cfg)
+		baseGroup := e.Group(cfg.BasePath)
+		registerInfraRoutes(baseGroup, cfg)
 
 		// BasePath (versioning or gateway-fiendly)
 		root := http.NewServeMux()
@@ -191,12 +195,12 @@ func Start(cfg Config) func(ctx context.Context, e *echo.Echo) func(context.Cont
 	}
 }
 
-func registerInfraRoutes(e *echo.Echo, cfg Config) {
-	e.GET(cfg.BasePath+"/healthz", func(c echo.Context) error {
+func registerInfraRoutes(g *echo.Group, cfg Config) {
+	g.GET("/healthz", func(c echo.Context) error {
 		return c.String(http.StatusOK, "ok")
 	})
 
 	if cfg.EnablePprof {
-		e.Any(cfg.BasePath+"/debug/pprof/*", echo.WrapHandler(http.DefaultServeMux))
+		g.Any("/debug/pprof/*", echo.WrapHandler(http.DefaultServeMux))
 	}
 }

--- a/internal/platform/module.go
+++ b/internal/platform/module.go
@@ -174,7 +174,7 @@ func resolveSinkPath(path, fallback string) string {
 }
 
 // Routes implements core.Module.
-func (m *module) Routes(e *echo.Echo, c *core.Container) error {
+func (m *module) Routes(g *echo.Group, c *core.Container) error {
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- normalize the configured server base path and apply it once before registering routes
- register module route sets against a shared base group so individual registerRoutes only declare their own resource groupings
- update infra routes (healthz/pprof) and lint a guardrails file to keep health checks and linting passing

## Testing
- go test ./...
- /usr/local/bin/golangci-lint run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692500c063f88322b90ead8c1b3b76df)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lançamento

* **Refactor**
  * Simplificada a configuração de caminho base da aplicação com normalização automática de caminhos.
  * Reorganizado o sistema de roteamento para melhor estruturação e escalabilidade.
  * Padrão de caminho base ajustado para "/api" (antes "/api/v1").

* **Chores**
  * Otimizadas as configurações internas de servidor HTTP.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->